### PR TITLE
CU-8692mknp5: Allow changing only names when renaming meta annotations

### DIFF
--- a/medcat/evaluate_mct_export/mct_analysis.py
+++ b/medcat/evaluate_mct_export/mct_analysis.py
@@ -240,7 +240,6 @@ class MedcatTrainer_export(object):
         If you want to rename the values but keep the names, it would be suggested
         to have the `meta_anns2rename` a dict mappign the names to themselves.
 
-        TODO: the meta_ann_values2rename has issues
         :param meta_anns2rename: Example input: `{'Subject/Experiencer': 'Subject'}`
         :param meta_ann_values2rename: Example input: `{'Subject':{'Relative':'Other'}}`
         :return:

--- a/medcat/evaluate_mct_export/mct_analysis.py
+++ b/medcat/evaluate_mct_export/mct_analysis.py
@@ -245,6 +245,11 @@ class MedcatTrainer_export(object):
         :param meta_ann_values2rename: Example input: `{'Subject':{'Relative':'Other'}}`
         :return:
         """
+        # if we want to rename the values, but haven't specified any names to rename
+        # we need to use a names dict to map the names to themselves due to the way
+        # the current implementation works
+        if meta_ann_values2rename and not meta_anns2rename:
+            meta_anns2rename = dict((name, name) for name in meta_ann_values2rename)
         for _, _, ann in self._iter_anns(False, False):
             meta_anns = ann['meta_anns']
             if len(meta_anns) > 0:

--- a/medcat/evaluate_mct_export/mct_analysis.py
+++ b/medcat/evaluate_mct_export/mct_analysis.py
@@ -235,11 +235,6 @@ class MedcatTrainer_export(object):
     def rename_meta_anns(self, meta_anns2rename: dict = dict(), meta_ann_values2rename: dict = dict()):
         """Rename the names and/or values of meta annotations.
 
-        PS!
-        The renaming of values is currently only supported if renaming names as well.
-        If you want to rename the values but keep the names, it would be suggested
-        to have the `meta_anns2rename` a dict mappign the names to themselves.
-
         :param meta_anns2rename: Example input: `{'Subject/Experiencer': 'Subject'}`
         :param meta_ann_values2rename: Example input: `{'Subject':{'Relative':'Other'}}`
         :return:

--- a/tests/medcat/evaluate_mct_export/test_mct_analysis.py
+++ b/tests/medcat/evaluate_mct_export/test_mct_analysis.py
@@ -168,3 +168,8 @@ class MCTExportMetaAnnRenameTests(unittest.TestCase):
                                      meta_ann_values2rename=self.VALUES2RENAME)
         self._check_names(prev_anns)
         self._check_values(prev_anns, only_values=False)
+
+    def test_meta_annotations_renamed_values_only(self):
+        prev_anns = list(self._get_all_meta_anns())
+        self.export.rename_meta_anns(meta_ann_values2rename=self.VALUES2RENAME)
+        self._check_values(prev_anns, only_values=True)


### PR DESCRIPTION
As far as I could tell, there was only one issue with renaming meta annotations:
- Only renaming values would not work
  - There was a documented workaround of supplying a self->self mapping for names
  - But not a great solution

This PR doe the following:
- When trying to change values, but no name renames are specified
  - Set the names to map to themselves
  - Based on the names that are involved with the names under which values are renamed

PS:
This will still fail to rename values if the user specified _some_ names they wanted to rename and values they wish to remap that are not a part of the names they're remapping.
But this could easily be done in two separate steps. And in fact, I'd argue it would be easier to follow in this situation as well.