### PR TITLE
CU-8699u4p99: Explicitly add elasticsearch dependency.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 spacy>=3.6.0,<4.0
 medcat~=1.16.0
 plotly~=5.19.0
-elasticsearch~=8.18.1
-eland~=8.12
+elasticsearch>=9.0.0,<10.0
+eland>=9.0.0,<10.0
 en_core_web_md @ https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.8.0/en_core_web_md-3.8.0-py3-none-any.whl
 ipyfilechooser
 jupyter_contrib_nbextensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 spacy>=3.6.0,<4.0
 medcat~=1.16.0
 plotly~=5.19.0
-eland==8.12.1
+elasticsearch~=8.18.1
+eland~=8.12
 en_core_web_md @ https://github.com/explosion/spacy-models/releases/download/en_core_web_md-3.8.0/en_core_web_md-3.8.0-py3-none-any.whl
 ipyfilechooser
 jupyter_contrib_nbextensions


### PR DESCRIPTION
Also allow later `eland` versions.

The previous `requirements.txt` didn't specify `elasticsearch` as a dependency. Though parts of the project do use and require it.
At the same time, an `eland` requirement was specified, which mean a compatible `elasticsearch` version was available.
This was most likely because some time ago (before Feburary 20 2023; medct v1.7.0) `medcat` itself declared an `elasticsearch` dependency and working_with_cogstack was probably trying to work with the version that the library supported.

This PR explicitly states the `elasticsearch` dependency.
Though I've allowed for a more wide range than before, on both `elasticsearch` and `eland`.

This is (currently) set to ES8 because (as far as I know) some sites still use ES8 (e.g KCH), while other sites use ES9 (GSTT).

PS:
I am not fully sure whether this setup would work for both ES8 and ES9. But I've left it at v8 for now.

PPS:
Currently, none of the ES-specific stuff is automatically tested (as far as I know). So it's hard to tell what does and doesn't work. Adding automated tests for this is on the roadmap, but is waiting on a few other things to happen first.